### PR TITLE
ln: Treat parameters consistently with native ln.

### DIFF
--- a/src/ln.js
+++ b/src/ln.js
@@ -29,7 +29,7 @@ function _ln(options, source, dest) {
     common.error('Missing <source> and/or <dest>');
   }
 
-  source = path.resolve(process.cwd(), String(source));
+  source = String(source);
   dest = path.resolve(process.cwd(), String(dest));
 
   if (!fs.existsSync(source)) {

--- a/test/ln.js
+++ b/test/ln.js
@@ -47,7 +47,7 @@ assert.equal(
   'new content 1'
 );
 
-shell.ln('-s', 'tmp/file2', 'tmp/linkfile2');
+shell.ln('-s', 'file2', 'tmp/linkfile2');
 assert(fs.existsSync('tmp/linkfile2'));
 assert.equal(
   fs.readFileSync('tmp/file2').toString(),
@@ -71,7 +71,7 @@ assert.equal(
   'new content js'
 );
 
-shell.ln('-sf', 'tmp/file1.txt', 'tmp/file2.txt');
+shell.ln('-sf', 'file1.txt', 'tmp/file2.txt');
 assert(fs.existsSync('tmp/file2.txt'));
 assert.equal(
   fs.readFileSync('tmp/file1.txt').toString(),
@@ -84,7 +84,7 @@ assert.equal(
 );
 
 // Abspath regression
-shell.ln('-sf', 'tmp/file1', path.resolve('tmp/abspath'));
+shell.ln('-sf', 'file1', path.resolve('tmp/abspath'));
 assert(fs.existsSync('tmp/abspath'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
@@ -94,6 +94,23 @@ fs.writeFileSync('tmp/file1', 'new content 3');
 assert.equal(
   fs.readFileSync('tmp/abspath').toString(),
   'new content 3'
+);
+
+// Relative regression
+shell.ln('-sf', 'file1.txt', 'tmp/file2.txt');
+shell.mkdir('-p', 'tmp/new');
+// Move the symlink first, as the reverse confuses `mv`.
+shell.mv('tmp/file2.txt', 'tmp/new/file2.txt');
+shell.mv('tmp/file1.txt', 'tmp/new/file1.txt');
+assert(fs.existsSync('tmp/new/file2.txt'));
+assert.equal(
+  fs.readFileSync('tmp/new/file1.txt').toString(),
+  fs.readFileSync('tmp/new/file2.txt').toString()
+);
+fs.writeFileSync('tmp/new/file1.txt', 'new content txt');
+assert.equal(
+  fs.readFileSync('tmp/new/file2.txt').toString(),
+  'new content txt'
 );
 
 shell.exit(123);


### PR DESCRIPTION
Previously, ln resolved input paths to abspaths, moving the root
of relative paths to $PWD, whereas native `ln` treats the source
path as relative to the _destination_. This restores the latter
behaviour.shelljs